### PR TITLE
Add X-Forwarded-Proto for nginx location block non ssl

### DIFF
--- a/templates/default/appserver.nginx.conf.erb
+++ b/templates/default/appserver.nginx.conf.erb
@@ -30,6 +30,7 @@ server {
   }
 
   location @<%= @name %> {
+    proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
     proxy_redirect off;


### PR DESCRIPTION
Need this for combined server block of ssl and non-ssl when rails ````force_ssl```` is used.